### PR TITLE
Fix param pass

### DIFF
--- a/REST_API_v2/Incidents/list_incidents.py
+++ b/REST_API_v2/Incidents/list_incidents.py
@@ -26,7 +26,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import requests
-import json
 
 # Update to match your API key
 API_KEY = '3c3gRvzx7uGfMYEnWKvF'
@@ -55,17 +54,17 @@ def list_incidents():
         'since': SINCE,
         'until': UNTIL,
         'date_range': DATE_RANGE,
-        'statuses': STATUSES,
+        'statuses[]': STATUSES,
         'incident_key': INCIDENT_KEY,
-        'service_ids': SERVICE_IDS,
-        'team_ids': TEAM_IDS,
-        'user_ids': USER_IDS,
-        'urgencies': URGENCIES,
+        'service_ids[]': SERVICE_IDS,
+        'team_ids[]': TEAM_IDS,
+        'user_ids[]': USER_IDS,
+        'urgencies[]': URGENCIES,
         'time_zone': TIME_ZONE,
-        'sort_by': SORT_BY,
-        'include': INCLUDE
+        'sort_by[]': SORT_BY,
+        'include[]': INCLUDE
     }
-    r = requests.get(url, headers=headers, params=json.dumps(payload))
+    r = requests.get(url, headers=headers, params=payload)
     print 'Status Code: ' + str(r.status_code)
     print r.json()
 


### PR DESCRIPTION
The current implementation passes over the params incorrectly:-

```
https://api.pagerduty.com/incidents?%7B%22team_ids%22:%20[],%20%22date_range%22:%20%22%22,%20%22user_ids%22:%20[],%20%22statuses%22:%20[],%20%22urgencies%22:%20[],%20%22service_ids%22:%20[],%20%22since%22:%20%22%22,%20%22time_zone%22:%20%22UTC%22,%20%22sort_by%22:%20[],%20%22incident_key%22:%20%22%22,%20%22include%22:%20[],%20%22until%22:%20%22%22%7D
```

This translates to:-

```
https://api.pagerduty.com/incidents?{"team_ids": [], "date_range": "", "user_ids": [], "statuses": [], "urgencies": [], "service_ids": [], "since": "", "time_zone": "UTC", "sort_by": [], "incident_key": "", "include": [], "until": ""}
```

However, this fix correctly passes the params:-

```
https://api.pagerduty.com/incidents?date_range=&since=&time_zone=UTC&until=&incident_key=&service_ids%5B%5D=PJ2SPCD
```

Which translates to:-

```
https://api.pagerduty.com/incidents?date_range=&since=&time_zone=UTC&until=&incident_key=&service_ids[]=PJ2SPCD
```
