### PR TITLE
[AE-167] remove team_responder from API_Python_Examples

### DIFF
--- a/REST_API_v2/Users/create_user.py
+++ b/REST_API_v2/Users/create_user.py
@@ -37,7 +37,7 @@ PD_EMAIL = 'lucas@pagerduty.com'
 # Update to match your chosen parameters for the new user
 NAME = 'Insert user name here'
 EMAIL = 'insert_email@here.com'
-ROLE = 'user'  # Can be one of admin, user, team_responder, limited_user, read_only_user  # NOQA
+ROLE = 'user'  # Can be one of admin, user, limited_user, read_only_user  # NOQA
 
 
 def create_user():

--- a/REST_API_v2/Users/update_user.py
+++ b/REST_API_v2/Users/update_user.py
@@ -37,7 +37,7 @@ ID = 'P0TEZR0'
 # Update to match your chosen parameters
 NAME = 'Insert user name here'
 EMAIL = 'insert_email@here.com'
-ROLE = 'user'  # Can be one of admin, user, team_responder, limited_user, read_only_user  # NOQA
+ROLE = 'user'  # Can be one of admin, user, limited_user, read_only_user  # NOQA
 
 
 def update_user():


### PR DESCRIPTION
This update is supposed to remove all team_responder references from this repo since the role will be deprecated. The change should be merged after completion of AE-168 https://pagerduty.atlassian.net/browse/AE-168 & AE-165 https://pagerduty.atlassian.net/browse/AE-165, which is expected on April 19, 2019.